### PR TITLE
bugfix: 模版内部函数变量未正确解释

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,17 @@ console.log(compile('I am <%=name%>, and i like playing <%=man.game%>.'));
 
 console.log(compile('I am <%=name%><%if(man){%> and i like playing <%=man.game%><%}%>.'));
 
+console.log(compile([
+    'I am <%=name%><%if(man){%> and I like playing <%=man.game%><%}%>.',
+    'My favorite animates are ',
+    '<% animates.each(function(animate){ %>',
+        '<% if (animate.type !== invisibleType ){ %>',
+            '<%=animate.name%>, ',
+        '<% } %>',
+    '<% }); %>',
+    'etc.',
+].join('\n')));
+
 //console.log(compile('I am <%=name%><%if(man){%> and i like playing <%=man.game%><%}%>.<%include("./include.atpl")%>', ''));
 
 


### PR DESCRIPTION
见[第三个test case](https://github.com/leungwensen/primer-template/blob/master/test/test.js#L7)

内部`invisibleType`这个变量没有正确解释出来。

解决办法：[递归地获取模版内子函数的上下文，并抽取其中未定义的变量](https://github.com/leungwensen/primer-template/commit/0d5dc503a42e4e70bf4d3c9ab339ec3933496b47)
